### PR TITLE
Add ERD documentation

### DIFF
--- a/intelligent-appointment/README.md
+++ b/intelligent-appointment/README.md
@@ -28,7 +28,7 @@ The Starter kit package includes two main directories:
    * `/api` - Contains the sample code for an Azure Serverless function, which acts as the app gateway to establish a secured connection to your Intelligent appointments environment.
 ## Data model
 
-A simplified ERD describing the relationships between the main entities is available in [appointment-starter-kit/docs/ERD.md](appointment-starter-kit/docs/ERD.md).
+A simplified ERD describing the relationships between the main entities is available in [appointment-starter-kit/docs/ERD.md](appointment-starter-kit/docs/ERD.md). An example SQL schema derived from these interfaces is provided in [appointment-starter-kit/docs/schema.sql](appointment-starter-kit/docs/schema.sql).
 
 
 ## Getting started

--- a/intelligent-appointment/README.md
+++ b/intelligent-appointment/README.md
@@ -26,6 +26,10 @@ The Starter kit package includes two main directories:
 2. `/demo-web-app` - Contains examples of the demo web app with the Starter kit embedded, and a sample Azure function to demonstrate as the web app gateway.
    * `/src` - Contains the demo web app code with the Starter kit embedded.
    * `/api` - Contains the sample code for an Azure Serverless function, which acts as the app gateway to establish a secured connection to your Intelligent appointments environment.
+## Data model
+
+A simplified ERD describing the relationships between the main entities is available in [appointment-starter-kit/docs/ERD.md](appointment-starter-kit/docs/ERD.md).
+
 
 ## Getting started
 

--- a/intelligent-appointment/appointment-starter-kit/docs/ERD.md
+++ b/intelligent-appointment/appointment-starter-kit/docs/ERD.md
@@ -1,0 +1,72 @@
+# Data Model ERD
+
+The following diagram summarizes the main entities used by the appointment starter kit. This diagram was manually derived from the TypeScript interfaces in `lib/models`.
+
+```mermaid
+erDiagram
+    IAddress {
+        string streetOne
+        string streetTwo
+        string city
+        string state
+        string country
+        string postcode
+        string phoneNumber
+        string email
+    }
+    IBranch {
+        string id
+        string name
+        IAddress address
+    }
+    IAdvisor {
+        string id
+        string name
+        string role
+    }
+    IMeetingTimeRange {
+        Date startTime
+        Date endTime
+    }
+    IMeeting {
+        string id
+        string meetingTypeId
+        string branchId
+        IAdvisor agent
+        string note
+        boolean isVirtual
+        string virtualMeetingLink
+    }
+    IMeetingTopic {
+        string id
+        string name
+        string description
+    }
+    IMeetingType {
+        string id
+        string name
+        string description
+        number duration
+        number channelLimitation
+        string meetingTypeTopicId
+        string customerInstructions
+    }
+    ITimeSlot {
+        Date startTime
+        Date endTime
+        IAdvisor[] advisors
+    }
+    IUser {
+        string id
+        string fullName
+        string email
+    }
+
+    IBranch ||--|| IAddress : has
+    IMeeting ||--|| IMeetingTimeRange : extends
+    IMeeting }o--|| IBranch : "branch"
+    IMeeting }o--|| IMeetingType : "meeting type"
+    IMeeting }o--|| IAdvisor : "agent"
+    IMeetingType ||--|| IMeetingTopic : extends
+    ITimeSlot }o--|| IAdvisor : "advisors"
+```

--- a/intelligent-appointment/appointment-starter-kit/docs/schema.sql
+++ b/intelligent-appointment/appointment-starter-kit/docs/schema.sql
@@ -1,0 +1,80 @@
+-- SQL DDL representing the appointment starter kit data model
+
+-- Table storing branch addresses
+CREATE TABLE Address (
+    id SERIAL PRIMARY KEY,
+    street_one      VARCHAR(100),
+    street_two      VARCHAR(100),
+    city            VARCHAR(50),
+    state           VARCHAR(50),
+    country         VARCHAR(50),
+    postcode        VARCHAR(20),
+    phone_number    VARCHAR(50),
+    email           VARCHAR(100)
+);
+
+-- Branches reference an Address record
+CREATE TABLE Branch (
+    id VARCHAR(50) PRIMARY KEY,
+    name        VARCHAR(100) NOT NULL,
+    address_id  INTEGER REFERENCES Address(id)
+);
+
+-- Advisors that can be assigned to meetings or time slots
+CREATE TABLE Advisor (
+    id VARCHAR(50) PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    role VARCHAR(50)
+);
+
+-- Meeting topics provide high level categories
+CREATE TABLE MeetingTopic (
+    id VARCHAR(50) PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    description TEXT
+);
+
+-- Meeting types extend topics with additional settings
+CREATE TABLE MeetingType (
+    id VARCHAR(50) PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    description TEXT,
+    duration INTEGER,
+    channel_limitation INTEGER,
+    meeting_type_topic_id VARCHAR(50) REFERENCES MeetingTopic(id),
+    customer_instructions TEXT
+);
+
+-- Individual meeting records with scheduling information
+CREATE TABLE Meeting (
+    id VARCHAR(50) PRIMARY KEY,
+    meeting_type_id VARCHAR(50) REFERENCES MeetingType(id),
+    branch_id       VARCHAR(50) REFERENCES Branch(id),
+    agent_id        VARCHAR(50) REFERENCES Advisor(id),
+    note TEXT,
+    is_virtual BOOLEAN,
+    virtual_meeting_link TEXT,
+    start_time TIMESTAMP NOT NULL,
+    end_time   TIMESTAMP NOT NULL
+);
+
+-- Basic user account information
+CREATE TABLE UserAccount (
+    id VARCHAR(50) PRIMARY KEY,
+    first_name VARCHAR(50),
+    last_name  VARCHAR(50),
+    is_logged_in BOOLEAN
+);
+
+-- Available time slots and advisors assigned to them
+CREATE TABLE TimeSlot (
+    id SERIAL PRIMARY KEY,
+    start_time TIMESTAMP NOT NULL,
+    end_time   TIMESTAMP NOT NULL
+);
+
+CREATE TABLE TimeSlotAdvisor (
+    time_slot_id INTEGER REFERENCES TimeSlot(id),
+    advisor_id   VARCHAR(50) REFERENCES Advisor(id),
+    PRIMARY KEY (time_slot_id, advisor_id)
+);


### PR DESCRIPTION
## Summary
- add Mermaid ERD diagram documenting the appointment data model
- reference the ERD in the intelligent appointment README

## Testing
- `yarn workspace @fsi/appointment-starter-kit coverage` *(fails: Vitest runs in watch mode and does not exit)*

------
https://chatgpt.com/codex/tasks/task_e_683f4033d8188320a49ca05c70356e3c